### PR TITLE
Feature/argument list to long

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 group = "com.cinchfinancial.codeclimate"
 archivesBaseName = "codeclimate-codenarc"
-version = "1.0"
+version = "1.3.0"
 
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
@@ -17,14 +17,14 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.codenarc', name: 'CodeNarc', version: '1.0'
-    compile group: "org.codehaus.groovy", name: "groovy-all", version: "2.4.12"
+    compile group: 'org.codenarc', name: 'CodeNarc', version: '1.3'
+    compile group: "org.codehaus.groovy", name: "groovy-all", version: "2.4.16"
 
-    runtime "org.slf4j:slf4j-api:1.7.25"
-    runtime "org.slf4j:slf4j-simple:1.7.25"
+    runtime "org.slf4j:slf4j-api:1.7.26"
+    runtime "org.slf4j:slf4j-simple:1.7.26"
     runtime  group: 'org.gmetrics', name: 'GMetrics', version: '1.0'
 
-    testCompile 'org.apache.ant:ant:1.9.4'
+    testCompile 'org.apache.ant:ant:1.10.5'
     testCompile 'commons-cli:commons-cli:1.4'
     testCompile 'junit:junit:4.12'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 group = "com.cinchfinancial.codeclimate"
 archivesBaseName = "codeclimate-codenarc"
-version = "1.3.0"
+version = "1.4.0"
 
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
@@ -17,14 +17,14 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.codenarc', name: 'CodeNarc', version: '1.3'
+    compile group: 'org.codenarc', name: 'CodeNarc', version: '1.4'
     compile group: "org.codehaus.groovy", name: "groovy-all", version: "2.4.16"
 
     runtime "org.slf4j:slf4j-api:1.7.26"
     runtime "org.slf4j:slf4j-simple:1.7.26"
     runtime  group: 'org.gmetrics', name: 'GMetrics', version: '1.0'
 
-    testCompile 'org.apache.ant:ant:1.10.5'
+    testCompile 'org.apache.ant:ant:1.10.7'
     testCompile 'commons-cli:commons-cli:1.4'
     testCompile 'junit:junit:4.12'
 }

--- a/engine.json
+++ b/engine.json
@@ -8,6 +8,6 @@
   "languages": [
     "Groovy"
   ],
-  "version": "1.3.0",
+  "version": "1.4.0",
   "spec_version": "0.3.1"
 }

--- a/engine.json
+++ b/engine.json
@@ -3,11 +3,11 @@
   "description": "Static code analysis tool for Groovy",
   "maintainer": {
     "name": "Jeremy Isikoff",
-    "email": "jeremy+codeclimate-codenarc@cinchfinancial.com"
+    "email": "jisikoff+codeclimate-codenarc@gmail.com"
   },
   "languages": [
     "Groovy"
   ],
-  "version": "1.0.0",
+  "version": "1.3.0",
   "spec_version": "0.3.1"
 }

--- a/fixtures/ruleset_default_file/ruleset.xml
+++ b/fixtures/ruleset_default_file/ruleset.xml
@@ -29,7 +29,10 @@
         </rule-config>
     </ruleset-ref>
     <ruleset-ref path="rulesets/exceptions.xml"/>
-    <ruleset-ref path="rulesets/formatting.xml"/>
+    <ruleset-ref path="rulesets/formatting.xml">
+        <exclude name="ClassEndsWithBlankLine"/>
+        <exclude name="ClassStartsWithBlankLine"/>
+    </ruleset-ref>
     <ruleset-ref path="rulesets/generic.xml"/>
     <ruleset-ref path="rulesets/grails.xml"/>
     <ruleset-ref path="rulesets/groovyism.xml"/>

--- a/fixtures/specified_file/ruleset.xml
+++ b/fixtures/specified_file/ruleset.xml
@@ -29,7 +29,10 @@
         </rule-config>
     </ruleset-ref>
     <ruleset-ref path="rulesets/exceptions.xml"/>
-    <ruleset-ref path="rulesets/formatting.xml"/>
+    <ruleset-ref path="rulesets/formatting.xml">
+        <exclude name="ClassEndsWithBlankLine"/>
+        <exclude name="ClassStartsWithBlankLine"/>
+    </ruleset-ref>
     <ruleset-ref path="rulesets/generic.xml"/>
     <ruleset-ref path="rulesets/grails.xml"/>
     <ruleset-ref path="rulesets/groovyism.xml"/>

--- a/src/main/groovy/Config.groovy
+++ b/src/main/groovy/Config.groovy
@@ -1,6 +1,8 @@
 import groovy.json.JsonSlurper
 import groovy.util.FileNameFinder
 
+import java.nio.file.Paths
+
 class Config {
     static String DEFAULT_RULES = "java-basic"
     def args
@@ -52,7 +54,7 @@ class Config {
 //    }
 
     private def pathsToExclude() {
-        return parsedConfig.exclude_paths?.collect { appContext.codeFolder + File.separator + it }?.join(",")
+        return parsedConfig.exclude_paths?.collect { Paths.get(appContext.codeFolder, it) }?.join(",")
     }
 
     //if you specified the rules they should exist
@@ -67,20 +69,8 @@ class Config {
     }
 
     private def pathsToInclude() {
-        def includePaths = parsedConfig.include_paths?.join(" ")
-        def codeFolder = new File(appContext.codeFolder)
-
-        def files = new FileNameFinder().getFileNames(appContext.codeFolder, includePaths)
-
-        def i = files.iterator()
-        while(i.hasNext()) {
-            def name = i.next()
-            if(!name.endsWith(".groovy")) {
-                i.remove()
-            }
-        }
-
-        def fileNames = files.toString()
-        fileNames.substring(1, fileNames.length()-1).replaceAll("\\s+","")
+        def directories = parsedConfig.include_paths?.findAll {it.endsWith(File.separator) }?.collect { it + "**.groovy"}
+        def files = parsedConfig.include_paths?.findAll {it.endsWith(".groovy")}
+        (directories + files)?.collect { Paths.get(appContext.codeFolder, it.toString()) }?.join(",")
     }
 }

--- a/src/main/groovy/main.groovy
+++ b/src/main/groovy/main.groovy
@@ -25,10 +25,10 @@ class Main {
         def rulesetString = config.ruleSet() ? "-rulesetfiles=${config.ruleSet()}" : ""
 
         //good command with hardcoded classpath TODO:make more flexible with directory classpath
-        def cmd = "java -Dorg.slf4j.simpleLogger.defaultLogLevel=off -classpath /usr/src/app/lib/groovy-all-2.4.16.jar:/usr/src/app/lib/codeclimate-codenarc-1.3.0.jar:/usr/src/app/lib/CodeNarc-1.3.jar:/usr/src/app/lib/GMetrics-1.0.jar:/usr/src/app/lib/slf4j-api-1.7.26.jar:/usr/src/app/lib/slf4j-simple-1.7.26.jar org.codenarc.CodeNarc -basedir=${config.appContext.codeFolder} ${rulesetString} ${includesString} ${excludesString} -report=CodeClimateReportWriter".replaceAll(/\s\s+/, ' ')
+        def cmd = "java -Dorg.slf4j.simpleLogger.defaultLogLevel=off -classpath /usr/src/app/lib/groovy-all-2.4.16.jar:/usr/src/app/lib/codeclimate-codenarc-1.4.0.jar:/usr/src/app/lib/CodeNarc-1.4.jar:/usr/src/app/lib/GMetrics-1.0.jar:/usr/src/app/lib/slf4j-api-1.7.26.jar:/usr/src/app/lib/slf4j-simple-1.7.26.jar org.codenarc.CodeNarc -basedir=${config.appContext.codeFolder} ${rulesetString} ${includesString} ${excludesString} -report=CodeClimateReportWriter".replaceAll(/\s\s+/, ' ')
 
         //minimal for testing:
-        //def cmd = "java -Dorg.slf4j.simpleLogger.defaultLogLevel=off -classpath /usr/src/app/lib/groovy-all-2.4.16.jar:/usr/src/app/lib/CodeNarc-1.3.0.jar:/usr/src/app/lib/GMetrics-1.0.jar:/usr/src/app/lib/slf4j-api-1.7.26.jar:/usr/src/app/lib/slf4j-simple-1.7.26.jar org.codenarc.CodeNarc"
+        //def cmd = "java -Dorg.slf4j.simpleLogger.defaultLogLevel=off -classpath /usr/src/app/lib/groovy-all-2.4.16.jar:/usr/src/app/lib/CodeNarc-1.4.0.jar:/usr/src/app/lib/GMetrics-1.0.jar:/usr/src/app/lib/slf4j-api-1.7.26.jar:/usr/src/app/lib/slf4j-simple-1.7.26.jar org.codenarc.CodeNarc"
 
         //Log the command out
         def printErr = System.err.&println

--- a/src/main/groovy/main.groovy
+++ b/src/main/groovy/main.groovy
@@ -25,10 +25,10 @@ class Main {
         def rulesetString = config.ruleSet() ? "-rulesetfiles=${config.ruleSet()}" : ""
 
         //good command with hardcoded classpath TODO:make more flexible with directory classpath
-        def cmd = "java -Dorg.slf4j.simpleLogger.defaultLogLevel=off -classpath /usr/src/app/lib/groovy-all-2.4.12.jar:/usr/src/app/lib/codeclimate-codenarc-1.0.jar:/usr/src/app/lib/CodeNarc-1.0.jar:/usr/src/app/lib/GMetrics-1.0.jar:/usr/src/app/lib/slf4j-api-1.7.25.jar:/usr/src/app/lib/slf4j-simple-1.7.25.jar org.codenarc.CodeNarc -basedir=${config.appContext.codeFolder} ${rulesetString} ${includesString} ${excludesString} -report=CodeClimateReportWriter".replaceAll(/\s\s+/, ' ')
+        def cmd = "java -Dorg.slf4j.simpleLogger.defaultLogLevel=off -classpath /usr/src/app/lib/groovy-all-2.4.16.jar:/usr/src/app/lib/codeclimate-codenarc-1.3.0.jar:/usr/src/app/lib/CodeNarc-1.3.jar:/usr/src/app/lib/GMetrics-1.0.jar:/usr/src/app/lib/slf4j-api-1.7.26.jar:/usr/src/app/lib/slf4j-simple-1.7.26.jar org.codenarc.CodeNarc -basedir=${config.appContext.codeFolder} ${rulesetString} ${includesString} ${excludesString} -report=CodeClimateReportWriter".replaceAll(/\s\s+/, ' ')
 
         //minimal for testing:
-        //def cmd = "java -Dorg.slf4j.simpleLogger.defaultLogLevel=off -classpath /usr/src/app/lib/groovy-all-2.4.12.jar:/usr/src/app/lib/CodeNarc-1.0.jar:/usr/src/app/lib/GMetrics-1.0.jar:/usr/src/app/lib/slf4j-api-1.7.25.jar:/usr/src/app/lib/slf4j-simple-1.7.25.jar org.codenarc.CodeNarc"
+        //def cmd = "java -Dorg.slf4j.simpleLogger.defaultLogLevel=off -classpath /usr/src/app/lib/groovy-all-2.4.16.jar:/usr/src/app/lib/CodeNarc-1.3.0.jar:/usr/src/app/lib/GMetrics-1.0.jar:/usr/src/app/lib/slf4j-api-1.7.26.jar:/usr/src/app/lib/slf4j-simple-1.7.26.jar org.codenarc.CodeNarc"
 
         //Log the command out
         def printErr = System.err.&println

--- a/src/test/groovy/ConfigTest.groovy
+++ b/src/test/groovy/ConfigTest.groovy
@@ -23,4 +23,11 @@ class ConfigTest {
     assertEquals "file:fixtures/specified_file/ruleset.xml", config.ruleSet() //TODO:figure out how this doesn't need to be classpath file:
   }
 
+  @Test
+  public void filterFilesNotGroovyNew() {
+    def config = new Config([configFile: "fixtures/filter_paths_test/config.json", codeFolder: "/usr/src/app/fixtures/default"])
+    assertEquals "/usr/src/app/fixtures/default/**.groovy,/usr/src/app/fixtures/default/somedirectory/**.groovy,/usr/src/app/fixtures/default/1.groovy,/usr/src/app/fixtures/default/2.groovy,/usr/src/app/fixtures/default/3.groovy", config.pathsToAnalyze
+    assertTrue !config.pathsToAnalyze.contains("filefileToFilter.txt")
+  }
+
 }


### PR DESCRIPTION
This is to deal with HUGE projects where the number of files exceeds the capabilities of command line with previous code that listed every file.  This uses "directory/**.groovy" where possible and "file.groovy" where not possible depending on what codeclimate's config.json hands us on the way in.  This should drastically shorten the number of files handed to the command line while still filtering for only groovy files.